### PR TITLE
Add batch delete functionality for skills

### DIFF
--- a/app.go
+++ b/app.go
@@ -166,6 +166,16 @@ func (a *App) DeleteSkill(skillID string) error {
 	return nil
 }
 
+func (a *App) DeleteSkills(skillIDs []string) error {
+	for _, id := range skillIDs {
+		if err := a.storage.Delete(id); err != nil {
+			return err
+		}
+	}
+	go a.autoBackup()
+	return nil
+}
+
 // --- Install ---
 
 // ScanGitHub scans a GitHub repo for valid skills, marking already-installed ones.

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -9,14 +9,22 @@ interface Props {
   onDelete: () => void
   onUpdate?: () => void
   onMoveCategory: (category: string) => void
+  selectMode?: boolean
+  selected?: boolean
+  onToggleSelect?: () => void
 }
 
-export default function SkillCard({ skill, categories, onDelete, onUpdate, onMoveCategory }: Props) {
+export default function SkillCard({ skill, categories, onDelete, onUpdate, onMoveCategory, selectMode, selected, onToggleSelect }: Props) {
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null)
 
   const handleContextMenu = (e: React.MouseEvent) => {
+    if (selectMode) return
     e.preventDefault()
     setMenu({ x: e.clientX, y: e.clientY })
+  }
+
+  const handleClick = () => {
+    if (selectMode) onToggleSelect?.()
   }
 
   const menuItems = [
@@ -31,15 +39,35 @@ export default function SkillCard({ skill, categories, onDelete, onUpdate, onMov
   return (
     <>
       <div
-        draggable
-        onDragStart={e => e.dataTransfer.setData('skillId', skill.id)}
+        draggable={!selectMode}
+        onDragStart={e => !selectMode && e.dataTransfer.setData('skillId', skill.id)}
         onContextMenu={handleContextMenu}
-        className="relative bg-gray-800 border border-gray-700 rounded-xl p-4 cursor-grab hover:border-indigo-500 transition-colors group"
+        onClick={handleClick}
+        className={`relative bg-gray-800 border rounded-xl p-4 transition-colors group ${
+          selectMode ? 'cursor-pointer' : 'cursor-grab'
+        } ${
+          selected
+            ? 'border-indigo-500 bg-indigo-900/20'
+            : 'border-gray-700 hover:border-indigo-500'
+        }`}
       >
+        {selectMode && (
+          <div className="absolute top-2 left-2 z-10">
+            <div className={`w-4 h-4 rounded border-2 flex items-center justify-center ${
+              selected ? 'bg-indigo-500 border-indigo-500' : 'border-gray-500 bg-gray-700'
+            }`}>
+              {selected && (
+                <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </div>
+          </div>
+        )}
         {skill.hasUpdate && (
           <span className="absolute top-2 right-2 w-2.5 h-2.5 rounded-full bg-red-500" />
         )}
-        <div className="flex items-center gap-2 mb-2">
+        <div className={`flex items-center gap-2 mb-2 ${selectMode ? 'pl-5' : ''}`}>
           {skill.source === 'github'
             ? <Github size={14} className="text-gray-400" />
             : <FolderOpen size={14} className="text-gray-400" />}
@@ -47,15 +75,17 @@ export default function SkillCard({ skill, categories, onDelete, onUpdate, onMov
             {skill.source}
           </span>
         </div>
-        <p className="font-medium text-sm truncate">{skill.name}</p>
-        <div className="mt-3 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-          {skill.hasUpdate && (
-            <button onClick={onUpdate} className="text-xs text-indigo-400 hover:text-indigo-300 flex items-center gap-1">
-              <RefreshCw size={12} /> 更新
-            </button>
-          )}
-          <button onClick={onDelete} className="text-xs text-red-400 hover:text-red-300 ml-auto">删除</button>
-        </div>
+        <p className={`font-medium text-sm truncate ${selectMode ? 'pl-5' : ''}`}>{skill.name}</p>
+        {!selectMode && (
+          <div className="mt-3 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+            {skill.hasUpdate && (
+              <button onClick={onUpdate} className="text-xs text-indigo-400 hover:text-indigo-300 flex items-center gap-1">
+                <RefreshCw size={12} /> 更新
+              </button>
+            )}
+            <button onClick={onDelete} className="text-xs text-red-400 hover:text-red-300 ml-auto">删除</button>
+          </div>
+        )}
       </div>
       {menu && (
         <ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={() => setMenu(null)} />

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState, useCallback } from 'react'
 import {
   ListSkills, ListCategories, MoveSkillCategory,
-  DeleteSkill, ImportLocal, UpdateSkill, CheckUpdates, OpenFolderDialog
+  DeleteSkill, DeleteSkills, ImportLocal, UpdateSkill, CheckUpdates, OpenFolderDialog
 } from '../../wailsjs/go/main/App'
 import { EventsOn } from '../../wailsjs/runtime/runtime'
 import CategoryPanel from '../components/CategoryPanel'
 import SkillCard from '../components/SkillCard'
 import GitHubInstallDialog from '../components/GitHubInstallDialog'
-import { Github, FolderOpen, RefreshCw, Search } from 'lucide-react'
+import { Github, FolderOpen, RefreshCw, Search, Trash2, CheckSquare } from 'lucide-react'
 
 export default function Dashboard() {
   const [skills, setSkills] = useState<any[]>([])
@@ -16,6 +16,8 @@ export default function Dashboard() {
   const [search, setSearch] = useState('')
   const [showGitHub, setShowGitHub] = useState(false)
   const [dragOver, setDragOver] = useState(false)
+  const [selectMode, setSelectMode] = useState(false)
+  const [selectedIDs, setSelectedIDs] = useState<Set<string>>(new Set())
 
   const load = useCallback(async () => {
     const [s, c] = await Promise.all([ListSkills(), ListCategories()])
@@ -66,6 +68,38 @@ export default function Dashboard() {
     if (dir) { await ImportLocal(dir, selectedCat ?? ''); load() }
   }
 
+  const toggleSelectMode = () => {
+    setSelectMode(prev => !prev)
+    setSelectedIDs(new Set())
+  }
+
+  const toggleSelectID = (id: string) => {
+    setSelectedIDs(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleSelectAll = () => {
+    if (selectedIDs.size === filtered.length) {
+      setSelectedIDs(new Set())
+    } else {
+      setSelectedIDs(new Set(filtered.map(sk => sk.ID)))
+    }
+  }
+
+  const handleBatchDelete = async () => {
+    if (selectedIDs.size === 0) return
+    await DeleteSkills(Array.from(selectedIDs))
+    setSelectedIDs(new Set())
+    setSelectMode(false)
+    load()
+  }
+
+  const allSelected = filtered.length > 0 && selectedIDs.size === filtered.length
+
   return (
     <div
       className={`flex h-full relative ${dragOver ? 'ring-2 ring-inset ring-indigo-500' : ''}`}
@@ -98,18 +132,50 @@ export default function Dashboard() {
               className="w-full bg-gray-800 border border-gray-700 rounded-lg pl-8 pr-3 py-1.5 text-sm outline-none focus:border-indigo-500"
             />
           </div>
-          <button
-            onClick={() => CheckUpdates()}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-lg hover:bg-gray-800"
-          ><RefreshCw size={14} /> 检查更新</button>
-          <button
-            onClick={handleImportButton}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-lg hover:bg-gray-800"
-          ><FolderOpen size={14} /> 手动导入</button>
-          <button
-            onClick={() => setShowGitHub(true)}
-            className="flex items-center gap-1.5 px-4 py-1.5 text-sm bg-indigo-600 hover:bg-indigo-500 rounded-lg"
-          ><Github size={14} /> 从 GitHub 安装</button>
+
+          {selectMode ? (
+            <>
+              <button
+                onClick={toggleSelectAll}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-lg hover:bg-gray-800"
+              >
+                <CheckSquare size={14} />
+                {allSelected ? '取消全选' : '全选'}
+              </button>
+              <button
+                onClick={handleBatchDelete}
+                disabled={selectedIDs.size === 0}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-red-600 hover:bg-red-500 disabled:opacity-40 disabled:cursor-not-allowed rounded-lg"
+              >
+                <Trash2 size={14} /> 删除 {selectedIDs.size > 0 ? `(${selectedIDs.size})` : ''}
+              </button>
+              <button
+                onClick={toggleSelectMode}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-lg hover:bg-gray-800"
+              >
+                取消
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => CheckUpdates()}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-lg hover:bg-gray-800"
+              ><RefreshCw size={14} /> 检查更新</button>
+              <button
+                onClick={toggleSelectMode}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-lg hover:bg-gray-800"
+              ><CheckSquare size={14} /> 批量删除</button>
+              <button
+                onClick={handleImportButton}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white rounded-lg hover:bg-gray-800"
+              ><FolderOpen size={14} /> 手动导入</button>
+              <button
+                onClick={() => setShowGitHub(true)}
+                className="flex items-center gap-1.5 px-4 py-1.5 text-sm bg-indigo-600 hover:bg-indigo-500 rounded-lg"
+              ><Github size={14} /> 从 GitHub 安装</button>
+            </>
+          )}
         </div>
 
         {/* Skills grid */}
@@ -123,6 +189,9 @@ export default function Dashboard() {
                 onDelete={async () => { await DeleteSkill(sk.ID); load() }}
                 onUpdate={async () => { await UpdateSkill(sk.ID); load() }}
                 onMoveCategory={async cat => { await MoveSkillCategory(sk.ID, cat); load() }}
+                selectMode={selectMode}
+                selected={selectedIDs.has(sk.ID)}
+                onToggleSelect={() => toggleSelectID(sk.ID)}
               />
             ))}
           </div>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -17,6 +17,8 @@ export function DeleteCategory(arg1:string):Promise<void>;
 
 export function DeleteSkill(arg1:string):Promise<void>;
 
+export function DeleteSkills(arg1:Array<string>):Promise<void>;
+
 export function GetConfig():Promise<config.AppConfig>;
 
 export function GetEnabledTools():Promise<Array<config.ToolConfig>>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -26,6 +26,10 @@ export function DeleteSkill(arg1) {
   return window['go']['main']['App']['DeleteSkill'](arg1);
 }
 
+export function DeleteSkills(arg1) {
+  return window['go']['main']['App']['DeleteSkills'](arg1);
+}
+
 export function GetConfig() {
   return window['go']['main']['App']['GetConfig']();
 }


### PR DESCRIPTION
- Add DeleteSkills([]string) backend method to app.go that deletes multiple skills in sequence and triggers auto-backup once
- Update Wails JS bindings (App.js, App.d.ts) to expose DeleteSkills to frontend
- Update SkillCard to support selectMode: shows checkbox, highlights selected state, disables drag and context menu in selectMode
- Update Dashboard with batch delete UI: "批量删除" button enters selectMode, toolbar switches to show select-all, delete count, and cancel; clicking cards toggles selection

https://claude.ai/code/session_012VfrbsVcoPaw8C2sbvcMnP