### PR TITLE
Add skill hover tooltip with SKILL.md metadata preview

### DIFF
--- a/app.go
+++ b/app.go
@@ -176,6 +176,14 @@ func (a *App) DeleteSkills(skillIDs []string) error {
 	return nil
 }
 
+func (a *App) GetSkillMeta(skillID string) (*skill.SkillMeta, error) {
+	sk, err := a.storage.Get(skillID)
+	if err != nil {
+		return nil, err
+	}
+	return skill.ReadMeta(sk.Path)
+}
+
 // --- Install ---
 
 // ScanGitHub scans a GitHub repo for valid skills, marking already-installed ones.

--- a/core/skill/meta.go
+++ b/core/skill/meta.go
@@ -1,0 +1,81 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SkillMeta holds parsed YAML frontmatter from a SKILL.md file.
+// All fields are optional — missing fields remain zero values.
+type SkillMeta struct {
+	Name                   string `yaml:"name"                     json:"Name"`
+	Description            string `yaml:"description"              json:"Description"`
+	ArgumentHint           string `yaml:"argument-hint"            json:"ArgumentHint"`
+	AllowedTools           string `yaml:"allowed-tools"            json:"AllowedTools"`
+	Context                string `yaml:"context"                  json:"Context"`
+	DisableModelInvocation bool   `yaml:"disable-model-invocation" json:"DisableModelInvocation"`
+}
+
+// ReadMeta locates skill.md / skills.md (case-insensitive) inside skillPath,
+// extracts the YAML frontmatter block (between the first pair of --- delimiters),
+// and unmarshals it. Returns an empty SkillMeta when no frontmatter is present.
+func ReadMeta(skillPath string) (*SkillMeta, error) {
+	entries, err := os.ReadDir(skillPath)
+	if err != nil {
+		return &SkillMeta{}, nil
+	}
+
+	var mdPath string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		lower := strings.ToLower(e.Name())
+		if lower == "skill.md" || lower == "skills.md" {
+			mdPath = filepath.Join(skillPath, e.Name())
+			break
+		}
+	}
+	if mdPath == "" {
+		return &SkillMeta{}, nil
+	}
+
+	data, err := os.ReadFile(mdPath)
+	if err != nil {
+		return &SkillMeta{}, nil
+	}
+
+	frontmatter := extractFrontmatter(string(data))
+	if frontmatter == "" {
+		return &SkillMeta{}, nil
+	}
+
+	var meta SkillMeta
+	if err := yaml.Unmarshal([]byte(frontmatter), &meta); err != nil {
+		return &SkillMeta{}, nil
+	}
+	return &meta, nil
+}
+
+// extractFrontmatter returns the YAML content between the first pair of "---" lines.
+// Returns empty string if no valid frontmatter block is found.
+func extractFrontmatter(content string) string {
+	lines := strings.Split(content, "\n")
+	if len(lines) < 3 || strings.TrimSpace(lines[0]) != "---" {
+		return ""
+	}
+	var end int
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			end = i
+			break
+		}
+	}
+	if end == 0 {
+		return ""
+	}
+	return strings.Join(lines[1:end], "\n")
+}

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Github, FolderOpen, RefreshCw } from 'lucide-react'
 import ContextMenu from './ContextMenu'
 
@@ -12,10 +12,17 @@ interface Props {
   selectMode?: boolean
   selected?: boolean
   onToggleSelect?: () => void
+  onHoverStart?: (rect: DOMRect) => void
+  onHoverEnd?: () => void
 }
 
-export default function SkillCard({ skill, categories, onDelete, onUpdate, onMoveCategory, selectMode, selected, onToggleSelect }: Props) {
+export default function SkillCard({
+  skill, categories, onDelete, onUpdate, onMoveCategory,
+  selectMode, selected, onToggleSelect,
+  onHoverStart, onHoverEnd,
+}: Props) {
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
 
   const handleContextMenu = (e: React.MouseEvent) => {
     if (selectMode) return
@@ -25,6 +32,15 @@ export default function SkillCard({ skill, categories, onDelete, onUpdate, onMov
 
   const handleClick = () => {
     if (selectMode) onToggleSelect?.()
+  }
+
+  const handleMouseEnter = () => {
+    if (selectMode) return
+    if (cardRef.current) onHoverStart?.(cardRef.current.getBoundingClientRect())
+  }
+
+  const handleMouseLeave = () => {
+    onHoverEnd?.()
   }
 
   const menuItems = [
@@ -39,10 +55,13 @@ export default function SkillCard({ skill, categories, onDelete, onUpdate, onMov
   return (
     <>
       <div
+        ref={cardRef}
         draggable={!selectMode}
         onDragStart={e => !selectMode && e.dataTransfer.setData('skillId', skill.id)}
         onContextMenu={handleContextMenu}
         onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         className={`relative bg-gray-800 border rounded-xl p-4 transition-colors group ${
           selectMode ? 'cursor-pointer' : 'cursor-grab'
         } ${
@@ -79,11 +98,11 @@ export default function SkillCard({ skill, categories, onDelete, onUpdate, onMov
         {!selectMode && (
           <div className="mt-3 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
             {skill.hasUpdate && (
-              <button onClick={onUpdate} className="text-xs text-indigo-400 hover:text-indigo-300 flex items-center gap-1">
+              <button onClick={e => { e.stopPropagation(); onUpdate?.() }} className="text-xs text-indigo-400 hover:text-indigo-300 flex items-center gap-1">
                 <RefreshCw size={12} /> 更新
               </button>
             )}
-            <button onClick={onDelete} className="text-xs text-red-400 hover:text-red-300 ml-auto">删除</button>
+            <button onClick={e => { e.stopPropagation(); onDelete() }} className="text-xs text-red-400 hover:text-red-300 ml-auto">删除</button>
           </div>
         )}
       </div>

--- a/frontend/src/components/SkillTooltip.tsx
+++ b/frontend/src/components/SkillTooltip.tsx
@@ -1,0 +1,165 @@
+import { createPortal } from 'react-dom'
+import { Github, FolderOpen, Tag, Wrench, GitBranch, Calendar, Clock, Hash, ExternalLink } from 'lucide-react'
+
+interface SkillFull {
+  ID: string
+  Name: string
+  Category: string
+  Source: string
+  SourceURL: string
+  SourceSubPath: string
+  SourceSHA: string
+  LatestSHA: string
+  InstalledAt: string
+  UpdatedAt: string
+}
+
+interface SkillMeta {
+  Name: string
+  Description: string
+  ArgumentHint: string
+  AllowedTools: string
+  Context: string
+  DisableModelInvocation: boolean
+}
+
+interface Props {
+  skill: SkillFull
+  meta: SkillMeta | null
+  anchorRect: DOMRect
+}
+
+function fmt(dateStr: string): string {
+  if (!dateStr) return '—'
+  try {
+    return new Date(dateStr).toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' })
+  } catch {
+    return '—'
+  }
+}
+
+function shortSHA(sha: string): string {
+  return sha ? sha.slice(0, 7) : '—'
+}
+
+export default function SkillTooltip({ skill, meta, anchorRect }: Props) {
+  const TOOLTIP_WIDTH = 300
+  const TOOLTIP_MAX_HEIGHT = 400
+  const GAP = 8
+
+  // Position: prefer right side, fall back to left
+  let left = anchorRect.right + GAP
+  if (left + TOOLTIP_WIDTH > window.innerWidth - 8) {
+    left = anchorRect.left - TOOLTIP_WIDTH - GAP
+  }
+
+  // Align top with the card, shift up if it would overflow
+  let top = anchorRect.top
+  if (top + TOOLTIP_MAX_HEIGHT > window.innerHeight - 8) {
+    top = window.innerHeight - TOOLTIP_MAX_HEIGHT - 8
+  }
+
+  const displayName = meta?.Name || skill.Name
+  const isGitHub = skill.Source === 'github'
+
+  const tooltip = (
+    <div
+      style={{ left, top, width: TOOLTIP_WIDTH, maxHeight: TOOLTIP_MAX_HEIGHT }}
+      className="fixed z-50 overflow-y-auto bg-gray-900 border border-gray-700 rounded-xl shadow-2xl text-sm pointer-events-none"
+    >
+      {/* Header */}
+      <div className="px-4 pt-4 pb-3 border-b border-gray-800">
+        <div className="flex items-start gap-2">
+          <div className="mt-0.5 shrink-0 text-gray-400">
+            {isGitHub ? <Github size={14} /> : <FolderOpen size={14} />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-white leading-snug truncate">{displayName}</p>
+            <div className="flex items-center gap-1.5 mt-1">
+              <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                isGitHub ? 'bg-blue-900/60 text-blue-300' : 'bg-gray-800 text-gray-400'
+              }`}>
+                {skill.Source}
+              </span>
+              {skill.Category && (
+                <span className="text-xs text-gray-500 truncate">{skill.Category}</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Description */}
+        {meta === null ? (
+          <p className="mt-3 text-xs text-gray-500 italic">加载中…</p>
+        ) : meta.Description ? (
+          <p className="mt-3 text-xs text-gray-300 leading-relaxed">{meta.Description}</p>
+        ) : (
+          <p className="mt-3 text-xs text-gray-600 italic">暂无描述</p>
+        )}
+      </div>
+
+      {/* Frontmatter fields */}
+      {meta && (meta.ArgumentHint || meta.AllowedTools || meta.Context) && (
+        <div className="px-4 py-3 border-b border-gray-800 space-y-2">
+          {meta.ArgumentHint && (
+            <Row icon={<Tag size={12} />} label="参数提示">
+              <code className="text-xs bg-gray-800 px-1.5 py-0.5 rounded text-indigo-300 font-mono">
+                {meta.ArgumentHint}
+              </code>
+            </Row>
+          )}
+          {meta.AllowedTools && (
+            <Row icon={<Wrench size={12} />} label="允许工具">
+              <span className="text-xs text-gray-300">{meta.AllowedTools}</span>
+            </Row>
+          )}
+          {meta.Context && (
+            <Row icon={<GitBranch size={12} />} label="运行上下文">
+              <span className="text-xs text-indigo-300 font-mono">{meta.Context}</span>
+            </Row>
+          )}
+        </div>
+      )}
+
+      {/* Skill metadata */}
+      <div className="px-4 py-3 space-y-2">
+        {isGitHub && skill.SourceURL && (
+          <Row icon={<ExternalLink size={12} />} label="仓库">
+            <span className="text-xs text-indigo-400 truncate max-w-[160px]">
+              {skill.SourceURL.replace('https://github.com/', '')}
+              {skill.SourceSubPath ? `/${skill.SourceSubPath}` : ''}
+            </span>
+          </Row>
+        )}
+        {skill.SourceSHA && (
+          <Row icon={<Hash size={12} />} label="版本">
+            <code className="text-xs font-mono text-gray-300">{shortSHA(skill.SourceSHA)}</code>
+            {skill.LatestSHA && skill.LatestSHA !== skill.SourceSHA && (
+              <span className="ml-2 text-xs text-amber-400">可更新 → {shortSHA(skill.LatestSHA)}</span>
+            )}
+          </Row>
+        )}
+        <Row icon={<Calendar size={12} />} label="安装时间">
+          <span className="text-xs text-gray-400">{fmt(skill.InstalledAt)}</span>
+        </Row>
+        {skill.UpdatedAt && skill.UpdatedAt !== skill.InstalledAt && (
+          <Row icon={<Clock size={12} />} label="更新时间">
+            <span className="text-xs text-gray-400">{fmt(skill.UpdatedAt)}</span>
+          </Row>
+        )}
+      </div>
+    </div>
+  )
+
+  return createPortal(tooltip, document.body)
+}
+
+function Row({ icon, label, children }: { icon: React.ReactNode; label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-2">
+      <span className="text-gray-500 mt-0.5 shrink-0">{icon}</span>
+      <span className="text-gray-500 shrink-0 w-16 text-xs leading-relaxed">{label}</span>
+      <div className="flex items-center gap-1 min-w-0 flex-wrap">{children}</div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import {
   ListSkills, ListCategories, MoveSkillCategory,
-  DeleteSkill, DeleteSkills, ImportLocal, UpdateSkill, CheckUpdates, OpenFolderDialog
+  DeleteSkill, DeleteSkills, ImportLocal, UpdateSkill, CheckUpdates,
+  OpenFolderDialog, GetSkillMeta,
 } from '../../wailsjs/go/main/App'
 import { EventsOn } from '../../wailsjs/runtime/runtime'
 import CategoryPanel from '../components/CategoryPanel'
 import SkillCard from '../components/SkillCard'
+import SkillTooltip from '../components/SkillTooltip'
 import GitHubInstallDialog from '../components/GitHubInstallDialog'
 import { Github, FolderOpen, RefreshCw, Search, Trash2, CheckSquare } from 'lucide-react'
 
@@ -18,6 +20,11 @@ export default function Dashboard() {
   const [dragOver, setDragOver] = useState(false)
   const [selectMode, setSelectMode] = useState(false)
   const [selectedIDs, setSelectedIDs] = useState<Set<string>>(new Set())
+
+  // Hover tooltip state
+  const [hoveredSkill, setHoveredSkill] = useState<{ skill: any; rect: DOMRect } | null>(null)
+  const [hoveredMeta, setHoveredMeta] = useState<any | null>(null)
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const load = useCallback(async () => {
     const [s, c] = await Promise.all([ListSkills(), ListCategories()])
@@ -71,6 +78,7 @@ export default function Dashboard() {
   const toggleSelectMode = () => {
     setSelectMode(prev => !prev)
     setSelectedIDs(new Set())
+    clearHover()
   }
 
   const toggleSelectID = (id: string) => {
@@ -99,6 +107,27 @@ export default function Dashboard() {
   }
 
   const allSelected = filtered.length > 0 && selectedIDs.size === filtered.length
+
+  // Hover handlers
+  const clearHover = () => {
+    if (hoverTimer.current) clearTimeout(hoverTimer.current)
+    setHoveredSkill(null)
+    setHoveredMeta(null)
+  }
+
+  const handleHoverStart = (sk: any, rect: DOMRect) => {
+    if (hoverTimer.current) clearTimeout(hoverTimer.current)
+    hoverTimer.current = setTimeout(async () => {
+      setHoveredSkill({ skill: sk, rect })
+      setHoveredMeta(null)
+      const meta = await GetSkillMeta(sk.ID)
+      setHoveredMeta(meta)
+    }, 300)
+  }
+
+  const handleHoverEnd = () => {
+    clearHover()
+  }
 
   return (
     <div
@@ -192,6 +221,8 @@ export default function Dashboard() {
                 selectMode={selectMode}
                 selected={selectedIDs.has(sk.ID)}
                 onToggleSelect={() => toggleSelectID(sk.ID)}
+                onHoverStart={rect => handleHoverStart(sk, rect)}
+                onHoverEnd={handleHoverEnd}
               />
             ))}
           </div>
@@ -203,6 +234,14 @@ export default function Dashboard() {
           )}
         </div>
       </div>
+
+      {hoveredSkill && (
+        <SkillTooltip
+          skill={hoveredSkill.skill}
+          meta={hoveredMeta}
+          anchorRect={hoveredSkill.rect}
+        />
+      )}
 
       {showGitHub && (
         <GitHubInstallDialog onClose={() => setShowGitHub(false)} onDone={() => { setShowGitHub(false); load() }} />

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -21,6 +21,8 @@ export function DeleteSkills(arg1:Array<string>):Promise<void>;
 
 export function GetConfig():Promise<config.AppConfig>;
 
+export function GetSkillMeta(arg1:string):Promise<skill.SkillMeta>;
+
 export function GetEnabledTools():Promise<Array<config.ToolConfig>>;
 
 export function Greet(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -34,6 +34,10 @@ export function GetConfig() {
   return window['go']['main']['App']['GetConfig']();
 }
 
+export function GetSkillMeta(arg1) {
+  return window['go']['main']['App']['GetSkillMeta'](arg1);
+}
+
 export function GetEnabledTools() {
   return window['go']['main']['App']['GetEnabledTools']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -178,5 +178,29 @@ export namespace skill {
 		}
 	}
 
+	export class SkillMeta {
+	    Name: string;
+	    Description: string;
+	    ArgumentHint: string;
+	    AllowedTools: string;
+	    Context: string;
+	    DisableModelInvocation: boolean;
+
+	    static createFrom(source: any = {}) {
+	        return new SkillMeta(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.Name = source["Name"];
+	        this.Description = source["Description"];
+	        this.ArgumentHint = source["ArgumentHint"];
+	        this.AllowedTools = source["AllowedTools"];
+	        this.Context = source["Context"];
+	        this.DisableModelInvocation = source["DisableModelInvocation"];
+	    }
+	}
+
+
 }
 


### PR DESCRIPTION
- Add core/skill/meta.go: SkillMeta struct + ReadMeta() that parses YAML frontmatter from skill.md/skills.md (name, description, argument-hint, allowed-tools, context, disable-model-invocation)
- Add GetSkillMeta(skillID) App method + Wails bindings
- Add SkillMeta class to models.ts
- Add SkillTooltip component: fixed floating card rendered via portal, positioned right/left of hovered card with viewport overflow correction; shows description, frontmatter fields, source repo, SHA, install/update dates
- Update SkillCard: onHoverStart/onHoverEnd callbacks using useRef for accurate DOMRect; disabled in selectMode
- Update Dashboard: 300ms debounced hover → GetSkillMeta fetch → render SkillTooltip

https://claude.ai/code/session_012VfrbsVcoPaw8C2sbvcMnP