### PR TITLE
Replace list view with card grid in sync pages; add open-folder button

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 
 	"github.com/shinerio/skillflow/core/backup"
 	"github.com/shinerio/skillflow/core/config"
@@ -579,6 +581,20 @@ func (a *App) OpenFolderDialog() (string, error) {
 	return runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
 		Title: "选择 Skill 目录",
 	})
+}
+
+// OpenPath opens the given filesystem path in the OS default file manager.
+func (a *App) OpenPath(path string) error {
+	var cmd *exec.Cmd
+	switch goruntime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "windows":
+		cmd = exec.Command("explorer", path)
+	default:
+		cmd = exec.Command("xdg-open", path)
+	}
+	return cmd.Start()
 }
 
 // Greet is kept for Wails template compatibility.

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -1,8 +1,9 @@
 import { useRef, useState } from 'react'
-import { Github, FolderOpen, RefreshCw } from 'lucide-react'
+import { Github, FolderOpen, RefreshCw, FolderOpenDot } from 'lucide-react'
 import ContextMenu from './ContextMenu'
+import { OpenPath } from '../../wailsjs/go/main/App'
 
-interface Skill { id: string; name: string; category: string; source: 'github' | 'manual'; hasUpdate: boolean }
+interface Skill { id: string; name: string; category: string; source: 'github' | 'manual'; hasUpdate: boolean; path?: string }
 interface Props {
   skill: Skill
   categories: string[]
@@ -41,6 +42,11 @@ export default function SkillCard({
 
   const handleMouseLeave = () => {
     onHoverEnd?.()
+  }
+
+  const handleOpenFolder = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (skill.path) OpenPath(skill.path)
   }
 
   const menuItems = [
@@ -83,9 +89,25 @@ export default function SkillCard({
             </div>
           </div>
         )}
-        {skill.hasUpdate && (
+
+        {/* Open folder button — top-right, visible on hover */}
+        {!selectMode && skill.path && (
+          <button
+            onClick={handleOpenFolder}
+            title="打开目录"
+            className="absolute top-2 right-2 z-10 p-1 rounded text-gray-600 opacity-0 group-hover:opacity-100 hover:text-gray-200 hover:bg-gray-700 transition-all"
+          >
+            <FolderOpenDot size={14} />
+          </button>
+        )}
+
+        {skill.hasUpdate && !selectMode && (
+          <span className="absolute top-2 right-8 w-2.5 h-2.5 rounded-full bg-red-500" />
+        )}
+        {skill.hasUpdate && selectMode && (
           <span className="absolute top-2 right-2 w-2.5 h-2.5 rounded-full bg-red-500" />
         )}
+
         <div className={`flex items-center gap-2 mb-2 ${selectMode ? 'pl-5' : ''}`}>
           {skill.source === 'github'
             ? <Github size={14} className="text-gray-400" />
@@ -94,7 +116,7 @@ export default function SkillCard({
             {skill.source}
           </span>
         </div>
-        <p className={`font-medium text-sm truncate ${selectMode ? 'pl-5' : ''}`}>{skill.name}</p>
+        <p className={`font-medium text-sm truncate ${selectMode ? 'pl-5' : 'pr-5'}`}>{skill.name}</p>
         {!selectMode && (
           <div className="mt-3 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
             {skill.hasUpdate && (

--- a/frontend/src/components/SyncSkillCard.tsx
+++ b/frontend/src/components/SyncSkillCard.tsx
@@ -1,0 +1,71 @@
+import { FolderOpen, Github, FolderOpenDot } from 'lucide-react'
+import { OpenPath } from '../../wailsjs/go/main/App'
+
+interface Props {
+  name: string
+  subtitle?: string     // e.g. category or path hint
+  source?: string       // 'github' | 'manual' | undefined
+  path?: string         // filesystem path to open in file manager
+  selected: boolean
+  onToggle: () => void
+}
+
+export default function SyncSkillCard({ name, subtitle, source, path, selected, onToggle }: Props) {
+  const handleOpen = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (path) OpenPath(path)
+  }
+
+  return (
+    <div
+      onClick={onToggle}
+      className={`relative flex flex-col gap-2 p-3 rounded-xl border cursor-pointer transition-colors select-none ${
+        selected
+          ? 'bg-indigo-900/30 border-indigo-500'
+          : 'bg-gray-800 border-gray-700 hover:border-gray-500'
+      }`}
+    >
+      {/* Top-right: open folder button */}
+      {path && (
+        <button
+          onClick={handleOpen}
+          title="打开目录"
+          className="absolute top-2 right-2 p-1 rounded text-gray-500 hover:text-gray-200 hover:bg-gray-700 transition-colors"
+        >
+          <FolderOpenDot size={13} />
+        </button>
+      )}
+
+      {/* Source badge row */}
+      <div className="flex items-center gap-1.5 pr-6">
+        {source === 'github'
+          ? <Github size={12} className="text-gray-400 shrink-0" />
+          : <FolderOpen size={12} className="text-gray-400 shrink-0" />}
+        {source && (
+          <span className={`text-xs px-1.5 py-0.5 rounded ${
+            source === 'github' ? 'bg-blue-900/50 text-blue-300' : 'bg-gray-700 text-gray-400'
+          }`}>{source}</span>
+        )}
+      </div>
+
+      {/* Skill name */}
+      <p className="text-sm font-medium leading-snug truncate pr-5">{name}</p>
+
+      {/* Subtitle (category or path) */}
+      {subtitle && (
+        <p className="text-xs text-gray-500 truncate">{subtitle}</p>
+      )}
+
+      {/* Selection indicator */}
+      <div className={`absolute bottom-2 right-2 w-4 h-4 rounded border-2 flex items-center justify-center transition-colors ${
+        selected ? 'bg-indigo-500 border-indigo-500' : 'border-gray-600 bg-gray-700'
+      }`}>
+        {selected && (
+          <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -213,7 +213,7 @@ export default function Dashboard() {
             {filtered.map(sk => (
               <SkillCard
                 key={sk.ID}
-                skill={{ id: sk.ID, name: sk.Name, category: sk.Category, source: sk.Source, hasUpdate: !!sk.LatestSHA }}
+                skill={{ id: sk.ID, name: sk.Name, category: sk.Category, source: sk.Source, hasUpdate: !!sk.LatestSHA, path: sk.Path }}
                 categories={categories}
                 onDelete={async () => { await DeleteSkill(sk.ID); load() }}
                 onUpdate={async () => { await UpdateSkill(sk.ID); load() }}

--- a/frontend/src/pages/SyncPull.tsx
+++ b/frontend/src/pages/SyncPull.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { GetEnabledTools, ScanToolSkills, PullFromTool, PullFromToolForce, ListCategories } from '../../wailsjs/go/main/App'
 import ConflictDialog from '../components/ConflictDialog'
-import { ArrowDownToLine, AlertCircle, X } from 'lucide-react'
+import SyncSkillCard from '../components/SyncSkillCard'
+import { ArrowDownToLine, AlertCircle, X, CheckSquare, Square } from 'lucide-react'
 import { ToolIcon } from '../config/toolIcons'
 
 export default function SyncPull() {
@@ -29,6 +30,7 @@ export default function SyncPull() {
     setScanning(true)
     setScanned([])
     setScanError('')
+    setDone(false)
     try {
       const skills = await ScanToolSkills(selectedTool)
       setScanned(skills ?? [])
@@ -59,78 +61,130 @@ export default function SyncPull() {
     setSelected(next)
   }
 
+  const toggleAll = () => {
+    if (selected.size === scanned.length) {
+      setSelected(new Set())
+    } else {
+      setSelected(new Set(scanned.map((s: any) => s.Name)))
+    }
+  }
+
+  const allSelected = scanned.length > 0 && selected.size === scanned.length
+
   return (
-    <div className="p-8 max-w-2xl">
-      <h2 className="text-lg font-semibold mb-6 flex items-center gap-2"><ArrowDownToLine size={18} /> 从工具拉取</h2>
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="p-8 pb-0">
+        <h2 className="text-lg font-semibold mb-6 flex items-center gap-2">
+          <ArrowDownToLine size={18} /> 从工具拉取
+        </h2>
 
-      {/* Tool select */}
-      <section className="mb-4">
-        <p className="text-sm text-gray-400 mb-3">来源工具</p>
-        <div className="flex flex-wrap gap-2">
-          {tools.map(t => (
-            <button
-              key={t.name}
-              onClick={() => { setSelectedTool(t.name); setScanned([]); setDone(false); setScanError(''); setScannedOnce(false) }}
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-colors ${selectedTool === t.name ? 'bg-indigo-600 border-indigo-500 text-white' : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-500'}`}
-            >
-              <ToolIcon name={t.name} size={20} />
-              {t.name}
+        {/* Tool select */}
+        <section className="mb-4">
+          <p className="text-sm text-gray-400 mb-3">来源工具</p>
+          <div className="flex flex-wrap gap-2">
+            {tools.map(t => (
+              <button
+                key={t.name}
+                onClick={() => {
+                  setSelectedTool(t.name)
+                  setScanned([])
+                  setDone(false)
+                  setScanError('')
+                  setScannedOnce(false)
+                }}
+                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-colors ${
+                  selectedTool === t.name
+                    ? 'bg-indigo-600 border-indigo-500 text-white'
+                    : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-500'
+                }`}
+              >
+                <ToolIcon name={t.name} size={20} />
+                {t.name}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <button
+          onClick={scan}
+          disabled={!selectedTool || scanning}
+          className="mb-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-sm disabled:opacity-50"
+        >
+          {scanning ? '扫描中...' : '扫描'}
+        </button>
+
+        {scanError && (
+          <div className="mb-4 flex items-start gap-2 bg-red-950 border border-red-700 text-red-300 rounded-lg px-4 py-3 text-sm">
+            <AlertCircle size={16} className="mt-0.5 shrink-0 text-red-400" />
+            <span className="flex-1">{scanError}</span>
+            <button onClick={() => setScanError('')} className="shrink-0 text-red-500 hover:text-red-300">
+              <X size={14} />
             </button>
-          ))}
-        </div>
-      </section>
+          </div>
+        )}
 
-      <button
-        onClick={scan} disabled={!selectedTool || scanning}
-        className="mb-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-sm disabled:opacity-50"
-      >{scanning ? '扫描中...' : '扫描'}</button>
-
-      {scanError && (
-        <div className="mb-4 flex items-start gap-2 bg-red-950 border border-red-700 text-red-300 rounded-lg px-4 py-3 text-sm">
-          <AlertCircle size={16} className="mt-0.5 shrink-0 text-red-400" />
-          <span className="flex-1">{scanError}</span>
-          <button onClick={() => setScanError('')} className="shrink-0 text-red-500 hover:text-red-300">
-            <X size={14} />
-          </button>
-        </div>
-      )}
-
-      {!scanError && !scanning && scannedOnce && scanned.length === 0 && (
-        <div className="mb-4 flex items-center gap-2 bg-yellow-950 border border-yellow-700 text-yellow-300 rounded-lg px-4 py-3 text-sm">
-          <AlertCircle size={16} className="shrink-0 text-yellow-400" />
-          <span>未发现任何 Skill，请确认工具目录中包含含有 skill.md 的子目录</span>
-        </div>
-      )}
+        {!scanError && !scanning && scannedOnce && scanned.length === 0 && (
+          <div className="mb-4 flex items-center gap-2 bg-yellow-950 border border-yellow-700 text-yellow-300 rounded-lg px-4 py-3 text-sm">
+            <AlertCircle size={16} className="shrink-0 text-yellow-400" />
+            <span>未发现任何 Skill，请确认工具目录中包含含有 skill.md 的子目录</span>
+          </div>
+        )}
+      </div>
 
       {scanned.length > 0 && (
         <>
-          <section className="mb-4">
-            <p className="text-sm text-gray-400 mb-2">选择要导入的 Skills（{selected.size}/{scanned.length}）</p>
-            <div className="max-h-52 overflow-y-auto space-y-1 border border-gray-700 rounded-xl p-3">
-              {scanned.map(sk => (
-                <label key={sk.Name} className="flex items-center gap-3 px-2 py-1.5 hover:bg-gray-800 rounded-lg cursor-pointer">
-                  <input type="checkbox" checked={selected.has(sk.Name)} onChange={() => toggle(sk.Name)} className="accent-indigo-500" />
-                  <span className="text-sm">{sk.Name}</span>
-                </label>
+          {/* Toolbar */}
+          <div className="px-8 mb-3 flex items-center gap-4">
+            <p className="text-sm text-gray-400">
+              选择要导入的 Skills
+              <span className="ml-1 text-gray-500">（{selected.size}/{scanned.length}）</span>
+            </p>
+            <button
+              onClick={toggleAll}
+              className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+            >
+              {allSelected ? <CheckSquare size={13} /> : <Square size={13} />}
+              {allSelected ? '取消全选' : '全选'}
+            </button>
+          </div>
+
+          {/* Card grid */}
+          <div className="flex-1 overflow-y-auto px-8">
+            <div className="grid grid-cols-3 xl:grid-cols-4 gap-3 pb-4">
+              {scanned.map((sk: any) => (
+                <SyncSkillCard
+                  key={sk.Name}
+                  name={sk.Name}
+                  path={sk.Path}
+                  selected={selected.has(sk.Name)}
+                  onToggle={() => toggle(sk.Name)}
+                />
               ))}
             </div>
-          </section>
+          </div>
 
-          <section className="mb-6 flex items-center gap-3">
-            <span className="text-sm text-gray-400">导入到分类</span>
-            <select value={targetCategory} onChange={e => setTargetCategory(e.target.value)}
-              className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-sm">
-              <option value="">Imported（默认）</option>
-              {categories.map(c => <option key={c} value={c}>{c}</option>)}
-            </select>
-          </section>
-
-          <button
-            onClick={pull} disabled={pulling || selected.size === 0}
-            className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 rounded-lg text-sm disabled:opacity-50"
-          >{pulling ? '拉取中...' : '开始拉取'}</button>
-
-          {done && <p className="mt-4 text-sm text-green-400">拉取完成</p>}
+          {/* Bottom action bar */}
+          <div className="px-8 py-4 border-t border-gray-800 flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-400">导入到分类</span>
+              <select
+                value={targetCategory}
+                onChange={e => setTargetCategory(e.target.value)}
+                className="bg-gray-800 border border-gray-700 rounded-lg px-3 py-1.5 text-sm"
+              >
+                <option value="">Imported（默认）</option>
+                {categories.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+            <button
+              onClick={pull}
+              disabled={pulling || selected.size === 0}
+              className="px-6 py-2 bg-indigo-600 hover:bg-indigo-500 rounded-lg text-sm disabled:opacity-50"
+            >
+              {pulling ? '拉取中...' : `开始拉取 (${selected.size})`}
+            </button>
+            {done && <span className="text-sm text-green-400">拉取完成 ✓</span>}
+          </div>
         </>
       )}
 

--- a/frontend/src/pages/SyncPush.tsx
+++ b/frontend/src/pages/SyncPush.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { GetEnabledTools, ListSkills, ListCategories, PushToTools, PushToToolsForce } from '../../wailsjs/go/main/App'
 import ConflictDialog from '../components/ConflictDialog'
-import { ArrowUpFromLine } from 'lucide-react'
+import SyncSkillCard from '../components/SyncSkillCard'
+import { ArrowUpFromLine, CheckSquare, Square } from 'lucide-react'
 import { ToolIcon } from '../config/toolIcons'
 
 type Scope = 'all' | 'category' | 'manual'
@@ -32,6 +33,10 @@ export default function SyncPush() {
     return [...selectedSkills]
   }
 
+  const manualSkills = scope === 'manual' ? skills : scope === 'category' && selectedCategory
+    ? skills.filter(s => s.Category === selectedCategory)
+    : skills
+
   const push = async () => {
     setPushing(true)
     setDone(false)
@@ -58,74 +63,149 @@ export default function SyncPush() {
     setSelectedSkills(next)
   }
 
+  const toggleAllManual = () => {
+    if (selectedSkills.size === skills.length) {
+      setSelectedSkills(new Set())
+    } else {
+      setSelectedSkills(new Set(skills.map(s => s.ID)))
+    }
+  }
+
+  const allManualSelected = skills.length > 0 && selectedSkills.size === skills.length
+
+  // Computed: how many skills will be pushed
+  const pushCount = scope === 'all'
+    ? skills.length
+    : scope === 'category'
+      ? skills.filter(s => s.Category === selectedCategory).length
+      : selectedSkills.size
+
   return (
-    <div className="p-8 max-w-2xl">
-      <h2 className="text-lg font-semibold mb-6 flex items-center gap-2"><ArrowUpFromLine size={18} /> 推送到工具</h2>
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="p-8 pb-0 shrink-0">
+        <h2 className="text-lg font-semibold mb-6 flex items-center gap-2">
+          <ArrowUpFromLine size={18} /> 推送到工具
+        </h2>
 
-      {/* Tool selection */}
-      <section className="mb-6">
-        <p className="text-sm text-gray-400 mb-3">目标工具</p>
-        <div className="flex flex-wrap gap-2">
-          {tools.map(t => (
-            <button
-              key={t.name}
-              onClick={() => toggleTool(t.name)}
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-colors ${selectedTools.has(t.name) ? 'bg-indigo-600 border-indigo-500 text-white' : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-500'}`}
-            >
-              <ToolIcon name={t.name} size={20} />
-              {t.name}
-            </button>
-          ))}
-        </div>
-      </section>
-
-      {/* Scope selection */}
-      <section className="mb-6">
-        <p className="text-sm text-gray-400 mb-3">同步范围</p>
-        <div className="space-y-2">
-          {([['all', '全部 Skills'], ['category', '按分类'], ['manual', '手动选择']] as [Scope, string][]).map(([v, label]) => (
-            <label key={v} className="flex items-center gap-3 cursor-pointer">
-              <input type="radio" checked={scope === v} onChange={() => setScope(v)} className="accent-indigo-500" />
-              <span className="text-sm">{label}</span>
-            </label>
-          ))}
-        </div>
-
-        {scope === 'category' && (
-          <select value={selectedCategory} onChange={e => setSelectedCategory(e.target.value)}
-            className="mt-3 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm w-48">
-            <option value="">选择分类</option>
-            {categories.map(c => <option key={c} value={c}>{c}</option>)}
-          </select>
-        )}
-
-        {scope === 'manual' && (
-          <div className="mt-3 max-h-52 overflow-y-auto space-y-1 border border-gray-700 rounded-xl p-3">
-            {skills.map(sk => (
-              <label key={sk.ID} className="flex items-center gap-3 px-2 py-1.5 hover:bg-gray-800 rounded-lg cursor-pointer">
-                <input type="checkbox" checked={selectedSkills.has(sk.ID)} onChange={() => toggleSkill(sk.ID)} className="accent-indigo-500" />
-                <span className="text-sm">{sk.Name}</span>
-                <span className="text-xs text-gray-500">{sk.Category || '未分类'}</span>
-              </label>
+        {/* Tool selection */}
+        <section className="mb-6">
+          <p className="text-sm text-gray-400 mb-3">目标工具</p>
+          <div className="flex flex-wrap gap-2">
+            {tools.map(t => (
+              <button
+                key={t.name}
+                onClick={() => toggleTool(t.name)}
+                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-colors ${
+                  selectedTools.has(t.name)
+                    ? 'bg-indigo-600 border-indigo-500 text-white'
+                    : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-500'
+                }`}
+              >
+                <ToolIcon name={t.name} size={20} />
+                {t.name}
+              </button>
             ))}
           </div>
-        )}
-      </section>
+        </section>
 
-      <button
-        onClick={push}
-        disabled={pushing || selectedTools.size === 0}
-        className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 rounded-lg text-sm disabled:opacity-50"
-      >{pushing ? '推送中...' : '开始推送'}</button>
+        {/* Scope selection */}
+        <section className="mb-4">
+          <p className="text-sm text-gray-400 mb-3">同步范围</p>
+          <div className="flex gap-3">
+            {([['all', '全部 Skills'], ['category', '按分类'], ['manual', '手动选择']] as [Scope, string][]).map(([v, label]) => (
+              <button
+                key={v}
+                onClick={() => setScope(v)}
+                className={`px-4 py-1.5 rounded-lg text-sm border transition-colors ${
+                  scope === v
+                    ? 'bg-indigo-600 border-indigo-500 text-white'
+                    : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-500'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
 
-      {done && <p className="mt-4 text-sm text-green-400">推送完成</p>}
+          {scope === 'category' && (
+            <select
+              value={selectedCategory}
+              onChange={e => setSelectedCategory(e.target.value)}
+              className="mt-3 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm w-48"
+            >
+              <option value="">选择分类</option>
+              {categories.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          )}
+        </section>
+      </div>
+
+      {/* Card grid for manual / category preview */}
+      {(scope === 'manual' || (scope === 'category' && selectedCategory)) && (
+        <>
+          <div className="px-8 mb-3 flex items-center gap-4 shrink-0">
+            <p className="text-sm text-gray-400">
+              {scope === 'manual' ? '选择要推送的 Skills' : `分类「${selectedCategory}」中的 Skills`}
+              <span className="ml-1 text-gray-500">
+                （{scope === 'manual' ? `${selectedSkills.size}/` : ''}{manualSkills.length}）
+              </span>
+            </p>
+            {scope === 'manual' && (
+              <button
+                onClick={toggleAllManual}
+                className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-white transition-colors"
+              >
+                {allManualSelected ? <CheckSquare size={13} /> : <Square size={13} />}
+                {allManualSelected ? '取消全选' : '全选'}
+              </button>
+            )}
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-8">
+            <div className="grid grid-cols-3 xl:grid-cols-4 gap-3 pb-4">
+              {manualSkills.map((sk: any) => (
+                <SyncSkillCard
+                  key={sk.ID}
+                  name={sk.Name}
+                  subtitle={sk.Category || undefined}
+                  source={sk.Source}
+                  path={sk.Path}
+                  selected={scope === 'manual' ? selectedSkills.has(sk.ID) : true}
+                  onToggle={() => scope === 'manual' && toggleSkill(sk.ID)}
+                />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* "全部" summary when no grid shown */}
+      {scope === 'all' && (
+        <div className="px-8 mt-2 flex-1">
+          <p className="text-sm text-gray-500">
+            将推送全部 <span className="text-white">{skills.length}</span> 个 Skills
+          </p>
+        </div>
+      )}
+
+      {/* Bottom action bar */}
+      <div className="px-8 py-4 border-t border-gray-800 shrink-0 flex items-center gap-4">
+        <button
+          onClick={push}
+          disabled={pushing || selectedTools.size === 0 || pushCount === 0}
+          className="px-6 py-2 bg-indigo-600 hover:bg-indigo-500 rounded-lg text-sm disabled:opacity-50"
+        >
+          {pushing ? '推送中...' : `开始推送 (${pushCount})`}
+        </button>
+        {done && <span className="text-sm text-green-400">推送完成 ✓</span>}
+      </div>
 
       {conflicts.length > 0 && (
         <ConflictDialog
           conflicts={conflicts}
           onOverwrite={async (name) => {
-            const skill = skills.find(s => s.Name === name)
-            if (skill) await PushToToolsForce([skill.ID], [...selectedTools])
+            const sk = skills.find(s => s.Name === name)
+            if (sk) await PushToToolsForce([sk.ID], [...selectedTools])
             setConflicts(prev => prev.filter(c => c !== name))
           }}
           onSkip={(name) => setConflicts(prev => prev.filter(c => c !== name))}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -43,6 +43,8 @@ export function MoveSkillCategory(arg1:string,arg2:string):Promise<void>;
 
 export function OpenFolderDialog():Promise<string>;
 
+export function OpenPath(arg1:string):Promise<void>;
+
 export function PullFromTool(arg1:string,arg2:Array<string>,arg3:string):Promise<Array<string>>;
 
 export function PullFromToolForce(arg1:string,arg2:Array<string>,arg3:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -78,6 +78,10 @@ export function OpenFolderDialog() {
   return window['go']['main']['App']['OpenFolderDialog']();
 }
 
+export function OpenPath(arg1) {
+  return window['go']['main']['App']['OpenPath'](arg1);
+}
+
 export function PullFromTool(arg1, arg2, arg3) {
   return window['go']['main']['App']['PullFromTool'](arg1, arg2, arg3);
 }


### PR DESCRIPTION
Sync pages (SyncPull / SyncPush):
- Replace checkbox list with responsive card grid (3–4 col) using new SyncSkillCard component
- SyncSkillCard: click to toggle selection, checkbox indicator bottom-right, source badge, open-folder button top-right
- SyncPull: full-height scroll area, select-all toggle, count in action bar, bottom action bar with category dropdown
- SyncPush: scope tabs styled as buttons (not radios), card preview for 'manual' and 'category' modes, 全部 mode shows summary text, push count shown in button

Open-folder button (all skill cards):
- Add OpenPath(path string) Go method using exec.Command (xdg-open/open/explorer per OS)
- Add OpenPath to Wails bindings
- SkillCard: FolderOpenDot button appears on hover at top-right, opens skill.Path
- Dashboard now passes sk.Path to SkillCard
- SyncSkillCard: same FolderOpenDot button, available for both stored and tool-directory skills

https://claude.ai/code/session_012VfrbsVcoPaw8C2sbvcMnP