### PR TITLE
fix: SSH/HTTP URL opening, source badge overflow, HTTP auth dialog

### DIFF
--- a/app.go
+++ b/app.go
@@ -254,8 +254,15 @@ func (a *App) ReadSkillFileContent(path string) (string, error) {
 }
 
 // OpenURL opens the given URL in the system default browser.
-func (a *App) OpenURL(url string) error {
-	runtime.BrowserOpenURL(a.ctx, url)
+// Non-HTTP URLs (e.g. SSH git remotes) are first converted to HTTPS.
+func (a *App) OpenURL(rawURL string) error {
+	target := rawURL
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		if canonical, err := coregit.CanonicalRepoURL(rawURL); err == nil {
+			target = canonical
+		}
+	}
+	runtime.BrowserOpenURL(a.ctx, target)
 	return nil
 }
 
@@ -825,6 +832,13 @@ func (a *App) AddStarredRepo(repoURL string) (*coregit.StarredRepo, error) {
 	}
 	repo := coregit.StarredRepo{URL: repoURL, Name: name, Source: source, LocalDir: localDir}
 	if cloneErr := coregit.CloneOrUpdate(a.ctx, repoURL, localDir, a.gitProxyURL()); cloneErr != nil {
+		// Return typed errors for auth failures so the frontend can show the right dialog.
+		if coregit.IsSSHAuthError(cloneErr) {
+			return nil, fmt.Errorf("AUTH_SSH:%s", cloneErr.Error())
+		}
+		if coregit.IsAuthError(cloneErr) {
+			return nil, fmt.Errorf("AUTH_HTTP:%s", cloneErr.Error())
+		}
 		repo.SyncError = cloneErr.Error()
 	} else {
 		repo.LastSync = time.Now()
@@ -834,6 +848,48 @@ func (a *App) AddStarredRepo(repoURL string) (*coregit.StarredRepo, error) {
 		return nil, err
 	}
 	return &repos[len(repos)-1], nil
+}
+
+// AddStarredRepoWithCredentials clones a repo using the provided HTTP username/password,
+// removing any previously failed entry for the same URL first.
+func (a *App) AddStarredRepoWithCredentials(repoURL, username, password string) (*coregit.StarredRepo, error) {
+	if err := coregit.CheckGitInstalled(); err != nil {
+		return nil, err
+	}
+	repos, err := a.starStorage.Load()
+	if err != nil {
+		return nil, err
+	}
+	// Remove any existing (possibly failed) entry for this URL.
+	filtered := repos[:0]
+	for _, r := range repos {
+		if !coregit.SameRepo(r.URL, repoURL) {
+			filtered = append(filtered, r)
+		}
+	}
+	name, err := coregit.ParseRepoName(repoURL)
+	if err != nil {
+		return nil, err
+	}
+	dataDir := filepath.Dir(a.cacheDir)
+	localDir, err := coregit.CacheDir(dataDir, repoURL)
+	if err != nil {
+		return nil, err
+	}
+	source, err := coregit.RepoSource(repoURL)
+	if err != nil {
+		return nil, err
+	}
+	repo := coregit.StarredRepo{URL: repoURL, Name: name, Source: source, LocalDir: localDir}
+	if cloneErr := coregit.CloneOrUpdateWithCreds(a.ctx, repoURL, localDir, a.gitProxyURL(), username, password); cloneErr != nil {
+		return nil, cloneErr
+	}
+	repo.LastSync = time.Now()
+	filtered = append(filtered, repo)
+	if err := a.starStorage.Save(filtered); err != nil {
+		return nil, err
+	}
+	return &filtered[len(filtered)-1], nil
 }
 
 func (a *App) RemoveStarredRepo(repoURL string) error {

--- a/core/git/client.go
+++ b/core/git/client.go
@@ -197,18 +197,64 @@ func GetSubPathSHA(ctx context.Context, repoDir, subPath string) (string, error)
 	return strings.TrimSpace(string(out)), nil
 }
 
+// IsAuthError reports whether err looks like an HTTP authentication failure from git.
+func IsAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "authentication failed") ||
+		strings.Contains(msg, "invalid username or password") ||
+		strings.Contains(msg, "could not read username") ||
+		strings.Contains(msg, "terminal prompts disabled") ||
+		strings.Contains(msg, "repository not found") ||
+		strings.Contains(msg, "http basic: access denied") ||
+		strings.Contains(msg, "the requested url returned error: 403") ||
+		strings.Contains(msg, "the requested url returned error: 401")
+}
+
+// IsSSHAuthError reports whether err looks like an SSH key authentication failure.
+func IsSSHAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "permission denied (publickey") ||
+		strings.Contains(msg, "no supported authentication methods") ||
+		(strings.Contains(msg, "could not read from remote repository") &&
+			!strings.Contains(msg, "http"))
+}
+
+// CloneOrUpdateWithCreds clones or updates a repo using embedded username/password for HTTP(S) URLs.
+// It always removes any partial clone directory first to ensure a clean state.
+func CloneOrUpdateWithCreds(ctx context.Context, repoURL, dir, proxyURL, username, password string) error {
+	cloneURL := repoURL
+	if (username != "" || password != "") && strings.Contains(repoURL, "://") {
+		if parsed, err := url.Parse(repoURL); err == nil &&
+			(parsed.Scheme == "https" || parsed.Scheme == "http") {
+			parsed.User = url.UserPassword(username, password)
+			cloneURL = parsed.String()
+		}
+	}
+	// Remove any partial clone so CloneOrUpdate always does a fresh clone.
+	_ = os.RemoveAll(dir)
+	return CloneOrUpdate(ctx, cloneURL, dir, proxyURL)
+}
+
 func runGit(ctx context.Context, dir, proxyURL string, args ...string) error {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	hideConsole(cmd)
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if proxyURL != "" {
-		cmd.Env = append(os.Environ(),
+		env = append(env,
 			"HTTP_PROXY="+proxyURL,
 			"HTTPS_PROXY="+proxyURL,
 			"http_proxy="+proxyURL,
 			"https_proxy="+proxyURL,
 		)
 	}
+	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))

--- a/frontend/src/components/SyncSkillCard.tsx
+++ b/frontend/src/components/SyncSkillCard.tsx
@@ -112,9 +112,9 @@ export default function SyncSkillCard({
             ? <Github size={12} className="text-gray-400 shrink-0" />
             : <FolderOpen size={12} className="text-gray-400 shrink-0" />}
           {source && (
-            <span className={`text-xs px-1.5 py-0.5 rounded ${
+            <span className={`text-xs px-1.5 py-0.5 rounded max-w-[72px] truncate ${
               source === 'github' ? 'bg-blue-900/50 text-blue-300' : 'bg-gray-700 text-gray-400'
-            }`}>{source}</span>
+            }`} title={source}>{source}</span>
           )}
           {imported && (
             <span className="text-xs bg-green-900/50 text-green-300 px-1.5 py-0.5 rounded">已导入</span>

--- a/frontend/src/pages/StarredRepos.tsx
+++ b/frontend/src/pages/StarredRepos.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
-  ListStarredRepos, AddStarredRepo, RemoveStarredRepo,
+  ListStarredRepos, AddStarredRepo, AddStarredRepoWithCredentials, RemoveStarredRepo,
   UpdateStarredRepo, UpdateAllStarredRepos,
   ListAllStarSkills, ListRepoStarSkills,
   ImportStarSkills, ListCategories, OpenURL,
@@ -10,7 +10,7 @@ import {
 import { EventsOn } from '../../wailsjs/runtime/runtime'
 import {
   Star, RefreshCw, Plus, Trash2, LayoutGrid, Folder,
-  ChevronLeft, CheckSquare, Download, AlertCircle, X, ExternalLink, ArrowUpToLine,
+  ChevronLeft, CheckSquare, Download, AlertCircle, X, ExternalLink, ArrowUpToLine, Lock, KeyRound,
 } from 'lucide-react'
 import SyncSkillCard from '../components/SyncSkillCard'
 
@@ -40,6 +40,14 @@ export default function StarredRepos() {
   const [pushingToTools, setPushingToTools] = useState(false)
   const [pushConflicts, setPushConflicts] = useState<string[]>([])
   const [showPushConflictDialog, setShowPushConflictDialog] = useState(false)
+  // Auth dialogs
+  const [showHttpAuthDialog, setShowHttpAuthDialog] = useState(false)
+  const [showSshErrorDialog, setShowSshErrorDialog] = useState(false)
+  const [authUrl, setAuthUrl] = useState('')
+  const [authUsername, setAuthUsername] = useState('')
+  const [authPassword, setAuthPassword] = useState('')
+  const [authError, setAuthError] = useState('')
+  const [authAdding, setAuthAdding] = useState(false)
 
   const loadRepos = async () => {
     const r = await ListStarredRepos()
@@ -80,8 +88,30 @@ export default function StarredRepos() {
       setShowAdd(false); setAddUrl('')
       await Promise.all([loadRepos(), loadAllSkills()])
     } catch (e: any) {
-      setAddError(String(e?.message ?? e ?? '添加失败'))
+      const msg = String(e?.message ?? e ?? '添加失败')
+      if (msg.startsWith('AUTH_SSH:')) {
+        setShowAdd(false)
+        setShowSshErrorDialog(true)
+      } else if (msg.startsWith('AUTH_HTTP:')) {
+        setAuthUrl(addUrl)
+        setAuthUsername(''); setAuthPassword(''); setAuthError('')
+        setShowHttpAuthDialog(true)
+      } else {
+        setAddError(msg)
+      }
     } finally { setAdding(false) }
+  }
+
+  const handleAuthRetry = async () => {
+    setAuthAdding(true); setAuthError('')
+    try {
+      await AddStarredRepoWithCredentials(authUrl, authUsername, authPassword)
+      setShowHttpAuthDialog(false)
+      setShowAdd(false); setAddUrl('')
+      await Promise.all([loadRepos(), loadAllSkills()])
+    } catch (e: any) {
+      setAuthError(String(e?.message ?? e ?? '认证失败'))
+    } finally { setAuthAdding(false) }
   }
 
   const handleUpdateAll = async () => {
@@ -352,6 +382,69 @@ export default function StarredRepos() {
         </div>
       )}
 
+      {/* HTTP auth dialog */}
+      {showHttpAuthDialog && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+          <div className="bg-gray-800 rounded-2xl p-6 w-[460px] border border-gray-700">
+            <div className="flex justify-between items-center mb-1">
+              <h3 className="font-semibold flex items-center gap-2"><Lock size={16} /> 需要认证</h3>
+              <button onClick={() => setShowHttpAuthDialog(false)}><X size={16} className="text-gray-400" /></button>
+            </div>
+            <p className="text-xs text-gray-500 mb-4">仓库需要用户名和密码（或 Access Token）才能访问</p>
+            <div className="space-y-2 mb-4">
+              <input
+                value={authUsername}
+                onChange={e => setAuthUsername(e.target.value)}
+                placeholder="用户名"
+                className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm outline-none focus:border-indigo-500"
+              />
+              <input
+                type="password"
+                value={authPassword}
+                onChange={e => setAuthPassword(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && !authAdding && handleAuthRetry()}
+                placeholder="密码 / Access Token"
+                className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm outline-none focus:border-indigo-500"
+              />
+            </div>
+            {authError && (
+              <div className="flex items-start gap-2 bg-red-950 border border-red-700 text-red-300 rounded-lg px-4 py-3 text-sm mb-3">
+                <AlertCircle size={15} className="mt-0.5 shrink-0" />
+                <span>{authError}</span>
+              </div>
+            )}
+            <div className="flex gap-3">
+              <button onClick={handleAuthRetry} disabled={authAdding}
+                className="flex-1 py-2 bg-indigo-600 hover:bg-indigo-500 rounded-lg text-sm disabled:opacity-50">
+                {authAdding ? '连接中...' : '确认'}
+              </button>
+              <button onClick={() => setShowHttpAuthDialog(false)}
+                className="flex-1 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-sm">取消</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* SSH auth error dialog */}
+      {showSshErrorDialog && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+          <div className="bg-gray-800 rounded-2xl p-6 w-[460px] border border-gray-700">
+            <h3 className="font-semibold mb-2 flex items-center gap-2 text-amber-400">
+              <KeyRound size={16} /> SSH 认证失败
+            </h3>
+            <p className="text-sm text-gray-300 mb-3">无法使用 SSH 访问远程仓库，请检查以下配置：</p>
+            <ul className="text-sm text-gray-400 space-y-1.5 list-disc list-inside mb-4">
+              <li>SSH 密钥是否已生成（<code className="text-gray-300">ssh-keygen</code>）</li>
+              <li>公钥是否已添加到 GitHub / GitLab 等远程仓库</li>
+              <li>SSH Agent 是否正在运行（<code className="text-gray-300">ssh-add</code>）</li>
+              <li>可尝试改用 HTTPS 协议克隆</li>
+            </ul>
+            <button onClick={() => setShowSshErrorDialog(false)}
+              className="w-full py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-sm">关闭</button>
+          </div>
+        </div>
+      )}
+
       {/* Push conflict dialog */}
       {showPushConflictDialog && (
         <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
@@ -449,19 +542,23 @@ function SkillGrid({ skills, selectMode, selectedPaths, onToggle, showRepo = fal
   }
   return (
     <div className="grid grid-cols-3 xl:grid-cols-4 gap-4">
-      {skills.map((sk: any) => (
+      {skills.map((sk: any) => {
+        const src = sk.source || sk.repoUrl || ''
+        const sourceType = src.includes('github.com') ? 'github' : src ? 'git' : undefined
+        return (
         <SyncSkillCard
           key={sk.path}
           name={sk.name}
           path={sk.path}
-          source={sk.source || undefined}
+          source={sourceType}
           subtitle={showRepo ? sk.repoName : undefined}
           imported={sk.imported}
           showSelection={selectMode}
           selected={selectedPaths.has(sk.path)}
           onToggle={() => selectMode && onToggle(sk.path)}
         />
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -10,6 +10,8 @@ export function AddCustomTool(arg1:string,arg2:string):Promise<void>;
 
 export function AddStarredRepo(arg1:string):Promise<git.StarredRepo>;
 
+export function AddStarredRepoWithCredentials(arg1:string,arg2:string,arg3:string):Promise<git.StarredRepo>;
+
 export function BackupNow():Promise<void>;
 
 export function CheckUpdates():Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -10,6 +10,10 @@ export function AddStarredRepo(arg1) {
   return window['go']['main']['App']['AddStarredRepo'](arg1);
 }
 
+export function AddStarredRepoWithCredentials(arg1, arg2, arg3) {
+  return window['go']['main']['App']['AddStarredRepoWithCredentials'](arg1, arg2, arg3);
+}
+
 export function BackupNow() {
   return window['go']['main']['App']['BackupNow']();
 }


### PR DESCRIPTION
- OpenURL backend always converts non-HTTPS git remotes (SSH, SCP) to https:// before calling BrowserOpenURL, preventing Windows dialog
- Set GIT_TERMINAL_PROMPT=0 on all git subprocesses so git never blocks waiting for terminal input
- Detect HTTP auth failures (401/403/authentication failed) and SSH key failures (permission denied publickey) in CloneOrUpdate; return typed error prefix AUTH_HTTP: / AUTH_SSH: to frontend
- Add AddStarredRepoWithCredentials(url, user, pass) App method that embeds credentials in the HTTPS clone URL via url.UserPassword
- Frontend: on AUTH_HTTP error show username/password dialog and retry; on AUTH_SSH error show SSH key configuration guidance dialog
- Fix SkillGrid JSX bracket syntax (missing } closing arrow function body)
- Add max-w-[72px] truncate to source badge in SyncSkillCard to prevent overflow when source string is unexpectedly long

https://claude.ai/code/session_01Gu9rgicsqj13NYenyw7QCV