### PR TITLE
chore: bump version to v1.0.7

### DIFF
--- a/cmd/skillflow/version.go
+++ b/cmd/skillflow/version.go
@@ -1,4 +1,4 @@
 package main
 
 // Version is set at build time via -ldflags "-X main.Version=vX.Y.Z".
-var Version = "v1.0.6"
+var Version = "v1.0.7"


### PR DESCRIPTION
## Summary

- bump the default desktop app version constant to `v1.0.7`
- align `main` with the already published `v1.0.7` release tag

## Test Plan

- [x] `go test ./...`
- [x] `npm run test:unit`
