### PR TITLE
build: align release version injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,43 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
       - name: Install Wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+      - name: Resolve build version
+        id: build-version
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            BUILD_VERSION="${GITHUB_REF_NAME}"
+          elif [ -n "${{ inputs.release_tag }}" ]; then
+            BUILD_VERSION="${{ inputs.release_tag }}"
+          else
+            BUILD_VERSION="rehearsal-${GITHUB_RUN_ID}"
+          fi
+
+          if [[ "$BUILD_VERSION" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            PRODUCT_VERSION="${BASH_REMATCH[1]}"
+          else
+            PRODUCT_VERSION="0.0.0"
+          fi
+
+          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "product_version=$PRODUCT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set bundle version
+        working-directory: cmd/skillflow
+        shell: bash
+        run: |
+          PRODUCT_VERSION="${{ steps.build-version.outputs.product_version }}"
+          PRODUCT_VERSION="$PRODUCT_VERSION" node -e '
+            const fs = require("fs");
+            const p = "wails.json";
+            const obj = JSON.parse(fs.readFileSync(p, "utf8"));
+            obj.info = { ...(obj.info || {}), productVersion: process.env.PRODUCT_VERSION };
+            fs.writeFileSync(p, JSON.stringify(obj, null, 2) + "\n");
+          '
       - name: Build
         working-directory: cmd/skillflow
-        run: wails build -platform ${{ matrix.arch == 'arm64' && 'darwin/arm64' || matrix.os == 'windows-latest' && 'windows/amd64' || 'darwin/amd64' }} -ldflags "-X main.Version=${{ github.ref_name }}"
+        run: wails build -platform ${{ matrix.arch == 'arm64' && 'darwin/arm64' || matrix.os == 'windows-latest' && 'windows/amd64' || 'darwin/amd64' }} -ldflags "-X main.Version=${{ steps.build-version.outputs.build_version }}"
 
       # macOS: package .app bundle into a drag-to-install DMG
       - name: Package macOS DMG

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ PROVIDER_BUILD_TAGS = $(strip provider_select $(foreach provider,$(call NORMALIZ
 WAILS_SKIP_FLAGS = $(shell $(BUILD_PLAN_CMD) plan)
 WAILS_BUILD_FLAGS = -trimpath -m -nosyncgomod $(WAILS_SKIP_FLAGS) $(if $(strip $(WAILS_BUILD_TAGS)),-tags "$(WAILS_BUILD_TAGS)") $(if $(strip $(WAILS_BUILD_LDFLAGS)),-ldflags "$(WAILS_BUILD_LDFLAGS)")
 
-.PHONY: all dev build build-cloud test test-cloud tidy generate install-frontend clean help
+.PHONY: all dev build build-version build-cloud test test-cloud tidy generate install-frontend clean help
 
 all: build
 
@@ -39,6 +39,18 @@ ifneq ($(OS),Windows_NT)
 		cp $(APP_DIR)/build/darwin/iconfile.icns $(APP_DIR)/build/bin/SkillFlow.app/Contents/Resources/iconfile.icns; \
 	fi
 endif
+
+## build-version: Build production binary with VERSION=vX.Y.Z and matching bundle version
+build-version:
+	$(if $(strip $(VERSION)),,$(error Usage: make build-version VERSION="v1.0.9"))
+	@set -e; \
+	backup="$(APP_DIR)/wails.json.bak"; \
+	cp $(APP_DIR)/wails.json "$$backup"; \
+	PRODUCT_VERSION=$$(printf '%s' "$(VERSION)" | sed 's/^v//') $(NODE) -e 'const fs=require("fs"); const p=process.argv[1]; const obj=JSON.parse(fs.readFileSync(p,"utf8")); obj.info={...(obj.info||{}), productVersion:process.env.PRODUCT_VERSION}; fs.writeFileSync(p, JSON.stringify(obj, null, 2)+"\n");' "$(APP_DIR)/wails.json"; \
+	status=0; \
+	$(MAKE) build WAILS_BUILD_LDFLAGS='$(WAILS_BUILD_LDFLAGS) -X main.Version=$(VERSION)' || status=$$?; \
+	mv "$$backup" $(APP_DIR)/wails.json; \
+	exit $$status
 
 ## build-cloud: Build with only selected cloud providers, e.g. make build-cloud PROVIDERS="aws,google"
 build-cloud:

--- a/cmd/skillflow/version.go
+++ b/cmd/skillflow/version.go
@@ -1,4 +1,4 @@
 package main
 
 // Version is set at build time via -ldflags "-X main.Version=vX.Y.Z".
-var Version = "v1.0.8"
+var Version = "dev"


### PR DESCRIPTION
## Summary
- align release version injection between local builds and GitHub Actions
- pin the Wails CLI version in CI
- default local app version to dev and inject release versions at build time

## Verification
- make build-version VERSION=v1.0.9
- verified built macOS bundle version is 1.0.9
- verified /Applications install is 1.0.9 arm64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Pinned Wails build dependency to stable version for reproducible builds.
  * Enhanced build pipeline with automated version resolution from Git tags and release inputs.
  * Updated development build version identification for improved tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->